### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+AI Outfit Suggestor (Closiq) — a FastAPI backend (Python 3.12) + React 19 frontend (TypeScript). See `README.md` for full architecture details.
+
+### Running services
+
+| Service | Command | Port | Notes |
+|---------|---------|------|-------|
+| Backend | `cd backend && source venv/bin/activate && python main.py` | 8001 | Requires PostgreSQL running and `backend/.env` configured |
+| Frontend | `cd frontend && npm start` | 3000 | Connects to backend via `REACT_APP_API_URL` in `frontend/.env` |
+
+### PostgreSQL
+
+PostgreSQL must be running before the backend starts. Start it with:
+```bash
+sudo pg_ctlcluster $(pg_lsclusters -h | awk '{print $1, $2}') start
+```
+
+The default database URL is `postgresql://postgres:postgres@localhost:5432/outfit_suggestor`. Tables are auto-created on backend startup via SQLAlchemy `Base.metadata.create_all`.
+
+### Running tests
+
+- **Backend (162 tests):** `cd backend && source venv/bin/activate && pytest tests/ -v --tb=short`
+  - Uses in-memory SQLite and mock AI services — no API keys or PostgreSQL needed.
+- **Frontend (137 tests):** `cd frontend && npm test -- --watchAll=false`
+- **Both:** `make test` from project root.
+
+### Linting
+
+- Frontend: ESLint is configured via `react-app` preset in `package.json`. Lint runs automatically as part of `react-scripts` build/start.
+- Backend: No explicit linter configured in the repo.
+
+### Environment files
+
+- `backend/.env` — required for backend startup. Copy from `backend/.env.example`. Key vars: `DATABASE_URL`, `OPENAI_API_KEY` (can be a placeholder if only running tests), `PORT`, `EMAIL_ENABLED=false`.
+- `frontend/.env` — optional. Defaults to `REACT_APP_API_URL=http://localhost:8001`.
+
+### Gotchas
+
+- The `backend/requirements.txt` has a malformed line (`pillow>=9.0.0==2.32.5`) that pip resolves by treating `requests` version separately — it installs fine but looks odd.
+- Backend tests use `pytest-asyncio` but the tests themselves are synchronous with `httpx.TestClient`.
+- Frontend uses Create React App (`react-scripts`), which bundles its own webpack dev server and ESLint.
+- The backend's `config.py` imports services at module level, so importing `config` triggers AI service initialization if `OPENAI_API_KEY` is set. Tests avoid this by using their own test fixtures.
+- `EMAIL_ENABLED=false` in `.env` skips email verification — users are auto-activated on registration.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents working on this repository.

## What's included

- Project overview and service descriptions
- Commands for running backend/frontend services
- PostgreSQL setup notes
- Test commands (backend: pytest, frontend: Jest)
- Environment file configuration guidance
- Non-obvious gotchas discovered during setup

## Development Environment Verification

The development environment was fully set up and verified:

- **Backend (FastAPI):** Running on port 8001, all 162 pytest tests passing
- **Frontend (React 19):** Running on port 3000, all 137 Jest tests passing, build succeeds
- **PostgreSQL:** Running with `outfit_suggestor` database
- **User registration and authenticated API calls:** Verified end-to-end

### Demo Screenshots

[Application dashboard in Chrome](https://cursor.com/agents/bc-89e30b12-f71b-4f08-a509-0a7804a75ddb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_dashboard_maximized.webp)

[Wardrobe management section](https://cursor.com/agents/bc-89e30b12-f71b-4f08-a509-0a7804a75ddb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwardrobe_section.webp)

[Outfit suggestion page](https://cursor.com/agents/bc-89e30b12-f71b-4f08-a509-0a7804a75ddb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foutfit_suggestion_page.webp)

[History section](https://cursor.com/agents/bc-89e30b12-f71b-4f08-a509-0a7804a75ddb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_section.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89e30b12-f71b-4f08-a509-0a7804a75ddb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89e30b12-f71b-4f08-a509-0a7804a75ddb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

