### PR TITLE
Set up Cursor Cloud dev environment (backend + web + Postgres)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,27 @@ Agents commit only when you explicitly ask.
 - [IOS_WEB_FEATURE_PARITY.md](IOS_WEB_FEATURE_PARITY.md)
 - [ARCHITECTURE.md](ARCHITECTURE.md)
 - [WEB_USER_INTERACTION.md](WEB_USER_INTERACTION.md)
+
+## Cursor Cloud specific instructions
+
+Dependencies (backend `venv`, `node_modules`) are refreshed by the startup update script. The notes below are runtime caveats that the update script intentionally does NOT handle.
+
+### Services (Linux cloud VM)
+
+| Service | Run command (from repo root) | Port | Notes |
+|---|---|---|---|
+| Backend API (FastAPI) | `cd backend && . venv/bin/activate && python main.py` | 8001 | Reads `backend/.env`. Health: `GET /`, `/health`, docs `/docs`. |
+| Web frontend (React/CRACO) | `cd frontend && BROWSER=none npm start` | 3000 | Talks to backend via `REACT_APP_API_URL` (`frontend/.env` → `http://localhost:8001`). |
+| PostgreSQL 16 | `sudo pg_ctlcluster 16 main start` | 5432 | Must be started each session (see below). DB `outfit_suggestor`, user/pass `postgres`/`postgres`. |
+| iOS client (`ios-client/`) | — | — | Requires macOS + Xcode; cannot build/run on this Linux VM. Source-only here. |
+
+### Startup caveats (non-obvious)
+
+- **PostgreSQL is not auto-started.** Run `sudo pg_ctlcluster 16 main start` at the start of each session before launching the backend (the backend auto-creates tables on startup once the DB is reachable). Verify with `pg_lsclusters`.
+- **`backend/.env` and `frontend/.env` are git-ignored** and live only in the VM snapshot. `backend/.env` sets `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/outfit_suggestor` and `EMAIL_ENABLED=false` (so signup works without SMTP). If the snapshot is reset, recreate them from the `.env.example` files.
+- **No `OPENAI_API_KEY` is set by default.** Auth, account creation, and non-AI reads/writes work, but AI-backed endpoints (`/api/suggest-outfit`, wardrobe AI analysis) — and `/api/outfit-history`, which shares the outfit controller dependency — return HTTP 500 with `OPENAI_API_KEY environment variable is not set`. In the web UI this surfaces as a CRA dev "Failed to fetch" error overlay (dismissable, non-blocking). To exercise AI features, add `OPENAI_API_KEY` to `backend/.env` and restart the backend.
+
+### Tests
+
+- Backend: `cd backend && . venv/bin/activate && pytest tests/ -q` (uses in-memory SQLite + mocked AI, so no Postgres/OpenAI needed).
+- Frontend: `cd frontend && CI=true npm test -- --watchAll=false` (MSW-mocked API).

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,6 @@ python-dotenv==1.1.1
 requests
 transformers>=4.30.0
 torch>=2.0.0
-pillow>=9.0.0==2.32.5
 SQLAlchemy==2.0.36
 psycopg2-binary==2.9.10
 imagehash==4.3.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the AI Outfit Suggestor so the backend API, React web frontend, and PostgreSQL all run on the Linux cloud VM, and documents the setup for future agents.

- Fixed a malformed pip requirement in `backend/requirements.txt` (`pillow>=9.0.0==2.32.5`) that broke `pip install` entirely; `pillow` is already pinned to `12.0.0` on an earlier line, so the corrupt duplicate line was removed.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering service run commands/ports, the PostgreSQL start caveat, git-ignored `.env` files, and the no-`OPENAI_API_KEY` behavior.

Environment provisioned during setup (not committed; lives in VM snapshot / update script):
- PostgreSQL 16 installed, cluster started, `outfit_suggestor` DB created (`postgres`/`postgres`).
- Backend Python venv + `pip install -r backend/requirements.txt`.
- Frontend `npm install`.
- `backend/.env` and `frontend/.env` created (git-ignored).

## Hello-world verification

Created a new user account end-to-end through the web UI (`Sign Up` → form → logged-in dashboard), with the account persisted to PostgreSQL. Auth flow also verified via curl (register → JWT → login) and DB row inspection.

[web_signup_hello_world.mp4](https://cursor.com/agents/bc-9b560756-da8e-47b9-986a-e376389be568/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_signup_hello_world.mp4)

[Logged-in dashboard after signup](https://cursor.com/agents/bc-9b560756-da8e-47b9-986a-e376389be568/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_logged_in_dashboard.webp)
[Account settings showing registered user](https://cursor.com/agents/bc-9b560756-da8e-47b9-986a-e376389be568/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_account_settings.webp)

## Testing

- Backend: `pytest tests/ -q` → 192 passed
- Frontend: `CI=true npm test -- --watchAll=false` → 292 passed
- Servers: backend `http://localhost:8001/health` 200, frontend `http://localhost:3000` 200

Note: without `OPENAI_API_KEY`, AI-backed endpoints (and `/api/outfit-history`, which shares the outfit controller dependency) return HTTP 500; the web UI surfaces this as a dismissable CRA "Failed to fetch" dev overlay. Auth/account creation works fully. The iOS client requires macOS/Xcode and cannot run on this Linux VM.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b560756-da8e-47b9-986a-e376389be568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b560756-da8e-47b9-986a-e376389be568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

